### PR TITLE
Add Sortable as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/SortableJS/react-mixin-sortablejs/issues"
   },
-  "homepage": "https://github.com/SortableJS/react-mixin-sortablejs#readme"
+  "homepage": "https://github.com/SortableJS/react-mixin-sortablejs#readme",
+  "dependencies": {
+    "sortablejs": "^1.4.2"
+  }
 }

--- a/react-mixin-sortable.js
+++ b/react-mixin-sortable.js
@@ -7,10 +7,10 @@
 	'use strict';
 
 	if (typeof module != 'undefined' && typeof module.exports != 'undefined') {
-		module.exports = factory(require('./Sortable'));
+		module.exports = factory(require('sortablejs/Sortable'));
 	}
 	else if (typeof define === 'function' && define.amd) {
-		define(['./Sortable'], factory);
+		define(['sortablejs/Sortable'], factory);
 	}
 	else {
 		/* jshint sub:true */


### PR DESCRIPTION
Hey,

I had Sortable plugin for a long time in my project but it failed on the new version of React. I added this mixin and got following error:

```
ERROR in ./~/react-mixin-sortablejs/react-mixin-sortable.js
Module not found: Error: Cannot resolve 'file' or 'directory' ./Sortable in /Users/JDS/Git/mobile/node_modules/react-mixin-sortablejs
 @ ./~/react-mixin-sortablejs/react-mixin-sortable.js 13:2-33
```

I made small fixes so please review it and merge if it looks good.
Feel free to criticize my changes. 
Thanks.
